### PR TITLE
Add CI for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,16 @@ jobs:
           distribution: 'adopt'
       - name: Build with Gradle
         run: ./gradlew build
+
+  build-on-Windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Gradle
+        run: ./gradlew.bat build

--- a/README.md
+++ b/README.md
@@ -30,4 +30,23 @@ And inside this `LibrariesForLibs.java` you see the problematic path in the java
         public Provider<MinimalExternalModuleDependency> getAssertj() { return create("assertj"); }
 ```
 
-`extra/userLib/settings.gradle` on my linux machine is turned to `extra\userLib\settings.gradle` on windows.
+`extra/userLib/settings.gradle` on my linux machine is turned to `extra\userLib\settings.gradle` on windows. As explained in the original issue `\u` is problematic.
+
+In the GitHub action run `build-on-Windows` the error can be seen (🔴 build):
+
+```
+FAILURE: Build failed with an exception.
+* What went wrong:
+org.gradle.api.internal.catalog.GeneratedClassCompilationException: Unable to compile generated sources:
+  - File LibrariesForLibs.java, line: 34, illegal unicode escape
+  - File LibrariesForLibs.java, line: 64, illegal unicode escape
+  - File LibrariesForLibs.java, line: 70, illegal unicode escape
+  - File LibrariesForLibs.java, line: 84, illegal unicode escape
+> Unable to compile generated sources:
+    - File LibrariesForLibs.java, line: 34, illegal unicode escape
+    - File LibrariesForLibs.java, line: 64, illegal unicode escape
+    - File LibrariesForLibs.java, line: 70, illegal unicode escape
+    - File LibrariesForLibs.java, line: 84, illegal unicode escape
+```
+
+The other build step using linux is working well (🟢 build)


### PR DESCRIPTION
Demonstration that this reproducer is producing the error we see in https://github.com/gradle/gradle/issues/19752

In the GitHub action run we see:
```
FAILURE: Build failed with an exception.
* What went wrong:
org.gradle.api.internal.catalog.GeneratedClassCompilationException: Unable to compile generated sources:
  - File LibrariesForLibs.java, line: 34, illegal unicode escape
  - File LibrariesForLibs.java, line: 64, illegal unicode escape
  - File LibrariesForLibs.java, line: 70, illegal unicode escape
  - File LibrariesForLibs.java, line: 84, illegal unicode escape
> Unable to compile generated sources:
    - File LibrariesForLibs.java, line: 34, illegal unicode escape
    - File LibrariesForLibs.java, line: 64, illegal unicode escape
    - File LibrariesForLibs.java, line: 70, illegal unicode escape
    - File LibrariesForLibs.java, line: 84, illegal unicode escape
```